### PR TITLE
Add login flow with role-aware navigation

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,11 @@ enum Currency {
   CNY
 }
 
+enum UserRole {
+  USER
+  ADMIN
+}
+
 enum TransactionType {
   EXPENSE
   INCOME
@@ -40,6 +45,7 @@ model User {
   email         String         @unique
   passwordHash  String
   fullName      String
+  role          UserRole       @default(USER)
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   categories    Category[]

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../common/prisma.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import * as argon2 from 'argon2';
+import { UserRole } from '@prisma/client';
 
 @Injectable()
 export class AuthService {
@@ -14,10 +15,11 @@ export class AuthService {
       data: {
         email: payload.email,
         passwordHash,
-        fullName: payload.fullName
+        fullName: payload.fullName,
+        role: payload.role ?? UserRole.USER
       }
     });
-    return { id: user.id, email: user.email, fullName: user.fullName };
+    return { id: user.id, email: user.email, fullName: user.fullName, role: user.role };
   }
 
   async login(payload: LoginDto) {
@@ -33,7 +35,13 @@ export class AuthService {
     }
     return {
       accessToken: 'mock-access-token',
-      refreshToken: 'mock-refresh-token'
+      refreshToken: 'mock-refresh-token',
+      user: {
+        id: user.id,
+        email: user.email,
+        fullName: user.fullName,
+        role: user.role
+      }
     };
   }
 

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, MinLength } from 'class-validator';
+import { UserRole } from '@prisma/client';
 
 export class RegisterDto {
   @ApiProperty()
@@ -13,4 +14,9 @@ export class RegisterDto {
   @ApiProperty()
   @MinLength(8)
   password!: string;
+
+  @ApiProperty({ enum: UserRole, required: false })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
 }

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -34,7 +34,8 @@ export class TransactionsService {
         notes: data.notes,
         exchangeRate: data.exchangeRate ?? null,
         userId: data.userId
-      }
+      },
+      include: { category: true, merchant: true }
     });
   }
 
@@ -45,7 +46,8 @@ export class TransactionsService {
         ...data,
         date: data.date ? new Date(data.date) : undefined,
         tags: data.tags ?? undefined
-      }
+      },
+      include: { category: true, merchant: true }
     });
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,45 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
+import { useMemo } from 'react';
 import { AppLayout } from '@components/layout/AppLayout';
 import { AdminConsolePage } from '@pages/AdminConsolePage';
 import { UserDashboardPage } from '@pages/UserDashboardPage';
+import { LoginPage } from '@pages/LoginPage';
+import { ProtectedRoute } from '@components/routing/ProtectedRoute';
+import { useAuthStore, selectIsAuthenticated } from '@store/authStore';
 
 const App = () => {
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const role = useAuthStore((state) => state.user?.role);
+
+  const defaultPath = useMemo(() => {
+    if (!isAuthenticated) {
+      return '/login';
+    }
+    return role === 'admin' ? '/admin' : '/user';
+  }, [isAuthenticated, role]);
+
   return (
     <Routes>
-      <Route element={<AppLayout />}>
-        <Route path="/" element={<Navigate to="/user" replace />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/" element={<Navigate to={defaultPath} replace />} />
+      <Route
+        element={
+          <ProtectedRoute>
+            <AppLayout />
+          </ProtectedRoute>
+        }
+      >
         <Route path="/user" element={<UserDashboardPage />} />
-        <Route path="/admin" element={<AdminConsolePage />} />
+        <Route
+          path="/admin"
+          element={
+            <ProtectedRoute requiredRole="admin">
+              <AdminConsolePage />
+            </ProtectedRoute>
+          }
+        />
       </Route>
+      <Route path="*" element={<Navigate to={defaultPath} replace />} />
     </Routes>
   );
 };

--- a/frontend/src/components/layout/ActionBar.tsx
+++ b/frontend/src/components/layout/ActionBar.tsx
@@ -35,6 +35,8 @@ export const ActionBar = () => {
           <option value="RUB">₽ Рубли</option>
           <option value="USD">$ Доллары</option>
           <option value="EUR">€ Евро</option>
+          <option value="GBP">£ Фунты</option>
+          <option value="CNY">¥ Юань</option>
         </select>
       </div>
       <div className="flex flex-wrap items-center gap-3">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,20 +1,33 @@
 import { LayoutDashboard, Layers, PieChart, Settings, ShieldCheck, Wallet } from 'lucide-react';
 import clsx from 'classnames';
 import { NavLink } from 'react-router-dom';
+import { useAuthStore } from '@store/authStore';
+import type { UserRole } from '@types/index';
 
-const workspaceNav = [
-  { icon: LayoutDashboard, label: 'Личный кабинет', to: '/user' },
-  { icon: ShieldCheck, label: 'Админ-панель', to: '/admin' }
+interface NavItem {
+  icon: typeof LayoutDashboard;
+  label: string;
+  to: string;
+  roles: UserRole[];
+}
+
+const workspaceNav: NavItem[] = [
+  { icon: LayoutDashboard, label: 'Личный кабинет', to: '/user', roles: ['user', 'admin'] },
+  { icon: ShieldCheck, label: 'Админ-панель', to: '/admin', roles: ['admin'] }
 ];
 
-const productNav = [
-  { icon: Wallet, label: 'Операции', to: '/user#transactions' },
-  { icon: Layers, label: 'Подписки', to: '/user#subscriptions' },
-  { icon: PieChart, label: 'Аналитика', to: '/user#analytics' },
-  { icon: Settings, label: 'Настройки', to: '/admin#settings' }
+const productNav: NavItem[] = [
+  { icon: Wallet, label: 'Операции', to: '/user#transactions', roles: ['user', 'admin'] },
+  { icon: Layers, label: 'Подписки', to: '/user#subscriptions', roles: ['user', 'admin'] },
+  { icon: PieChart, label: 'Аналитика', to: '/user#analytics', roles: ['user', 'admin'] },
+  { icon: Settings, label: 'Настройки', to: '/admin#settings', roles: ['admin'] }
 ];
 
 export const Sidebar = () => {
+  const role = useAuthStore((state) => state.user?.role ?? 'user');
+
+  const filterByRole = (items: NavItem[]) => items.filter((item) => item.roles.includes(role));
+
   return (
     <aside className="glass-panel hidden lg:flex w-72 flex-col justify-between p-8">
       <div>
@@ -28,7 +41,7 @@ export const Sidebar = () => {
         <div className="mt-10 space-y-6">
           <nav className="flex flex-col gap-2">
             <p className="px-4 text-xs uppercase tracking-widest text-slate-400">Рабочие области</p>
-            {workspaceNav.map(({ icon: Icon, label, to }) => (
+            {filterByRole(workspaceNav).map(({ icon: Icon, label, to }) => (
               <NavLink
                 key={to}
                 to={to}
@@ -50,7 +63,7 @@ export const Sidebar = () => {
           </nav>
           <nav className="flex flex-col gap-2">
             <p className="px-4 text-xs uppercase tracking-widest text-slate-400">Продукт</p>
-            {productNav.map(({ icon: Icon, label, to }) => (
+            {filterByRole(productNav).map(({ icon: Icon, label, to }) => (
               <NavLink
                 key={to}
                 to={to}

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,6 +1,7 @@
-import { Bell, ChevronDown, Menu, Moon, Search, Sun } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Bell, ChevronDown, LogOut, Menu, Moon, Search, Sun, UserCircle } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@store/authStore';
 
 const routeMeta: Record<
   string,
@@ -21,9 +22,14 @@ const routeMeta: Record<
 
 export const TopBar = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
+  const logout = useAuthStore((state) => state.logout);
   const [theme, setTheme] = useState<'light' | 'dark'>(() =>
     window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   );
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   const meta = useMemo(() => {
     const basePath = location.pathname.replace(/\/$/, '') || '/';
@@ -36,6 +42,33 @@ export const TopBar = () => {
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark');
   }, [theme]);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+    const handleClick = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handleClick);
+    return () => {
+      window.removeEventListener('mousedown', handleClick);
+    };
+  }, [isMenuOpen]);
+
+  const roleLabel = user?.role === 'admin' ? 'Администратор' : 'Пользователь';
+
+  const handleProfileNavigate = () => {
+    setIsMenuOpen(false);
+    const target = user?.role === 'admin' ? '/admin' : '/user#profile';
+    navigate(target);
+  };
+
+  const handleLogout = () => {
+    setIsMenuOpen(false);
+    logout();
+    navigate('/login', { replace: true });
+  };
 
   return (
     <header className="glass-panel flex items-center justify-between gap-4 px-4 py-3 md:px-6">
@@ -68,13 +101,44 @@ export const TopBar = () => {
         <button className="flex h-10 w-10 items-center justify-center rounded-full bg-white/70 shadow" type="button">
           <Bell size={18} />
         </button>
-        <div className="flex items-center gap-2 rounded-full bg-white/80 px-3 py-1">
-          <span className="h-8 w-8 rounded-full bg-gradient-to-br from-brand-400 to-brand-600" />
-          <div className="text-left">
-            <p className="text-xs text-slate-500">Анна Иванова</p>
-            <p className="text-sm font-semibold">Product Lead</p>
-          </div>
-          <ChevronDown size={16} className="text-slate-400" />
+        <div className="relative" ref={menuRef}>
+          <button
+            type="button"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            className="flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-left shadow"
+            aria-haspopup="menu"
+            aria-expanded={isMenuOpen}
+          >
+            <span className="h-8 w-8 rounded-full bg-gradient-to-br from-brand-400 to-brand-600" />
+            <div className="text-left">
+              <p className="text-xs text-slate-500">{user?.fullName ?? 'Профиль'}</p>
+              <p className="text-sm font-semibold capitalize">{roleLabel}</p>
+            </div>
+            <ChevronDown size={16} className="text-slate-400" />
+          </button>
+          {isMenuOpen && (
+            <div
+              role="menu"
+              className="absolute right-0 z-10 mt-2 w-56 rounded-2xl bg-white p-3 shadow-xl ring-1 ring-black/5"
+            >
+              <button
+                type="button"
+                onClick={handleProfileNavigate}
+                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm text-slate-600 hover:bg-slate-100"
+                role="menuitem"
+              >
+                <UserCircle size={18} /> Профиль
+              </button>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm text-red-500 hover:bg-red-50"
+                role="menuitem"
+              >
+                <LogOut size={18} /> Выйти
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </header>

--- a/frontend/src/components/routing/ProtectedRoute.tsx
+++ b/frontend/src/components/routing/ProtectedRoute.tsx
@@ -1,0 +1,26 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { useAuthStore, selectIsAuthenticated } from '@store/authStore';
+import type { UserRole } from '@types/index';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+  requiredRole?: UserRole;
+}
+
+export const ProtectedRoute = ({ children, requiredRole }: ProtectedRouteProps) => {
+  const location = useLocation();
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const user = useAuthStore((state) => state.user);
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  if (requiredRole && user?.role !== requiredRole) {
+    const fallback = user?.role === 'admin' ? '/admin' : '/user';
+    return <Navigate to={fallback} replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import type { Location } from 'react-router-dom';
+import { LogIn } from 'lucide-react';
+import { useAuthStore, selectIsAuthenticated } from '@store/authStore';
+
+export const LoginPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const login = useAuthStore((state) => state.login);
+  const status = useAuthStore((state) => state.status);
+  const error = useAuthStore((state) => state.error);
+  const user = useAuthStore((state) => state.user);
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isAuthenticated && user) {
+      const redirectTo =
+        (location.state as { from?: Location } | null)?.from?.pathname ??
+        (user.role === 'admin' ? '/admin' : '/user');
+      navigate(redirectTo, { replace: true });
+    }
+  }, [isAuthenticated, user, navigate, location.state]);
+
+  if (isAuthenticated && user) {
+    return <Navigate to={user.role === 'admin' ? '/admin' : '/user'} replace />;
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    try {
+      const authUser = await login({ email, password });
+      const redirectTo = (authUser.role === 'admin' ? '/admin' : '/user') as const;
+      navigate(redirectTo, { replace: true });
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : 'Не удалось выполнить вход';
+      setFormError(message);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-900/5 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="glass-panel flex w-full max-w-md flex-col gap-6 rounded-3xl p-8"
+      >
+        <div className="flex items-center gap-3">
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-600">
+            <LogIn size={24} />
+          </span>
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Войти в MinifyAI</h1>
+            <p className="text-sm text-slate-500">
+              Управляйте финансами и аналитикой в едином рабочем пространстве.
+            </p>
+          </div>
+        </div>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="text-xs uppercase tracking-widest text-slate-400">E-mail</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            className="rounded-2xl border border-white/60 bg-white/80 px-4 py-3 shadow-inner focus:outline-none"
+            placeholder="you@example.com"
+            autoComplete="email"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="text-xs uppercase tracking-widest text-slate-400">Пароль</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+            minLength={8}
+            className="rounded-2xl border border-white/60 bg-white/80 px-4 py-3 shadow-inner focus:outline-none"
+            placeholder="********"
+            autoComplete="current-password"
+          />
+        </label>
+        {(formError || error) && (
+          <div className="rounded-2xl bg-red-100 px-4 py-3 text-sm text-red-600">
+            {formError ?? error}
+          </div>
+        )}
+        <button
+          type="submit"
+          className="rounded-full bg-brand-500 px-4 py-3 text-sm font-semibold text-white shadow-lg disabled:opacity-60"
+          disabled={status === 'loading'}
+        >
+          {status === 'loading' ? 'Выполняем вход...' : 'Продолжить'}
+        </button>
+        <p className="text-center text-xs text-slate-400">
+          Доступ к админ-панели автоматически открывается для пользователей с ролью «admin».
+        </p>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/pages/UserDashboardPage.tsx
+++ b/frontend/src/pages/UserDashboardPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { ActionBar } from '@components/layout/ActionBar';
 import { BudgetAssistant } from '@features/BudgetAssistant';
 import { CashflowChart } from '@features/CashflowChart';
@@ -9,8 +10,17 @@ import { SubscriptionsPanel } from '@features/SubscriptionsPanel';
 import { SubscriptionForecast } from '@features/SubscriptionForecast';
 import { TransactionsTable } from '@features/TransactionsTable';
 import { TransactionComposer } from '@features/TransactionComposer';
+import { useDashboardStore } from '@store/dashboardStore';
 
 export const UserDashboardPage = () => {
+  const fetchTransactions = useDashboardStore((state) => state.fetchTransactions);
+
+  useEffect(() => {
+    fetchTransactions().catch((error) => {
+      console.error('Не удалось загрузить операции', error);
+    });
+  }, [fetchTransactions]);
+
   return (
     <div className="space-y-6">
       <ActionBar />

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,0 +1,90 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { apiClient } from '@utils/apiClient';
+import type { AuthUser, UserRole } from '@types/index';
+
+interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  status: 'idle' | 'loading';
+  error: string | null;
+  login: (payload: LoginPayload) => Promise<AuthUser>;
+  logout: () => void;
+  setUserRole: (role: UserRole) => void;
+}
+
+interface LoginResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: {
+    id: string;
+    email: string;
+    fullName: string;
+    role: string;
+  };
+}
+
+const toAuthUser = (payload: LoginResponse['user']): AuthUser => ({
+  id: payload.id,
+  email: payload.email,
+  fullName: payload.fullName,
+  role: (payload.role ?? 'user').toLowerCase() as UserRole
+});
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set, get) => ({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      status: 'idle',
+      error: null,
+      async login(payload) {
+        set({ status: 'loading', error: null });
+        try {
+          const response = await apiClient<LoginResponse>('/auth/login', {
+            method: 'POST',
+            body: JSON.stringify(payload)
+          }, { authenticated: false });
+          const user = toAuthUser(response.user);
+          set({
+            user,
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            status: 'idle',
+            error: null
+          });
+          return user;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Не удалось войти';
+          set({ status: 'idle', error: message });
+          throw error;
+        }
+      },
+      logout() {
+        set({ user: null, accessToken: null, refreshToken: null, status: 'idle', error: null });
+      },
+      setUserRole(role) {
+        const current = get().user;
+        if (!current) return;
+        set({ user: { ...current, role } });
+      }
+    }),
+    {
+      name: 'minifyai-auth',
+      partialize: (state) => ({
+        user: state.user,
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken
+      })
+    }
+  )
+);
+
+export const selectIsAuthenticated = (state: AuthState) => Boolean(state.accessToken && state.user);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,4 +1,13 @@
-export type CurrencyCode = 'RUB' | 'USD' | 'EUR';
+export type CurrencyCode = 'RUB' | 'USD' | 'EUR' | 'GBP' | 'CNY';
+
+export type UserRole = 'user' | 'admin';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  fullName: string;
+  role: UserRole;
+}
 
 export interface MoneyAmount {
   currency: CurrencyCode;

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -1,0 +1,58 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+
+interface ApiClientOptions {
+  authenticated?: boolean;
+  token?: string | null;
+  onUnauthorized?: () => void;
+}
+
+export async function apiClient<T>(
+  path: string,
+  init: RequestInit = {},
+  options: ApiClientOptions = {}
+): Promise<T> {
+  const { authenticated = true, token, onUnauthorized } = options;
+  const headers = new Headers(init.headers);
+
+  const isFormData = init.body instanceof FormData;
+  if (!isFormData && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  if (authenticated && token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers
+  });
+
+  if (response.status === 401) {
+    onUnauthorized?.();
+    throw new Error('Не авторизован');
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    let message = text;
+    try {
+      const data = JSON.parse(text);
+      message = data.message ?? data.error ?? message;
+    } catch (error) {
+      // ignore
+    }
+    throw new Error(message || 'Ошибка запроса');
+  }
+
+  if (!text) {
+    return undefined as T;
+  }
+
+  return JSON.parse(text) as T;
+}


### PR DESCRIPTION
## Summary
- add user role support to the backend schema and authentication responses so the frontend knows which routes to expose【F:backend/prisma/schema.prisma†L10-L55】【F:backend/src/auth/auth.service.ts†L6-L45】【F:backend/src/auth/dto/register.dto.ts†L1-L21】
- wire the dashboard store to the REST API for fetching and mutating transactions, and update the composer/table UI to handle async state and errors【F:frontend/src/store/dashboardStore.ts†L1-L457】【F:frontend/src/features/TransactionComposer.tsx†L35-L259】【F:frontend/src/features/TransactionsTable.tsx†L1-L126】
- introduce a persisted auth store, login page, and protected routes with role-aware sidebar/topbar navigation【F:frontend/src/store/authStore.ts†L1-L90】【F:frontend/src/pages/LoginPage.tsx†L1-L106】【F:frontend/src/components/routing/ProtectedRoute.tsx†L1-L25】【F:frontend/src/components/layout/Sidebar.tsx†L1-L94】【F:frontend/src/components/layout/TopBar.tsx†L1-L145】【F:frontend/src/App.tsx†L1-L45】

## Testing
- npm run build *(fails: missing ambient type packages in the environment)*【7a31ef†L1-L62】

------
https://chatgpt.com/codex/tasks/task_e_68e5709b77fc8321a35bee09eef4fb99