### PR TITLE
Implement profile section and AI assistant widget improvements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { AdminConsolePage } from '@pages/AdminConsolePage';
 import { UserDashboardPage } from '@pages/UserDashboardPage';
 import { LoginPage } from '@pages/LoginPage';
 import { ProtectedRoute } from '@components/routing/ProtectedRoute';
+import { NotFoundPage } from '@pages/NotFoundPage';
 import { useAuthStore, selectIsAuthenticated } from '@store/authStore';
 
 const App = () => {
@@ -39,7 +40,7 @@ const App = () => {
           }
         />
       </Route>
-      <Route path="*" element={<Navigate to={defaultPath} replace />} />
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 };

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from '@components/layout/Sidebar';
 import { TopBar } from '@components/layout/TopBar';
+import { BudgetAssistant } from '@features/BudgetAssistant';
 
 export const AppLayout = () => {
   return (
@@ -12,6 +13,7 @@ export const AppLayout = () => {
           <Outlet />
         </main>
       </div>
+      <BudgetAssistant />
     </div>
   );
 };

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { LayoutDashboard, Layers, PieChart, Settings, ShieldCheck, Wallet } from 'lucide-react';
 import clsx from 'classnames';
-import { NavLink } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useAuthStore } from '@store/authStore';
 import type { UserRole } from '@types/index';
 
@@ -25,63 +25,86 @@ const productNav: NavItem[] = [
 
 export const Sidebar = () => {
   const role = useAuthStore((state) => state.user?.role ?? 'user');
+  const location = useLocation();
+  const homePath = role === 'admin' ? '/admin' : '/user';
+
+  const normalizePath = (path: string) => path.replace(/\/$/, '') || '/';
+
+  const isNavItemActive = (target: string) => {
+    const [rawPath, rawHash] = target.split('#');
+    const targetPath = normalizePath(rawPath);
+    const currentPath = normalizePath(location.pathname);
+    if (targetPath !== currentPath) {
+      return false;
+    }
+    if (!rawHash) {
+      return true;
+    }
+    const targetHash = `#${rawHash}`;
+    return location.hash === targetHash;
+  };
 
   const filterByRole = (items: NavItem[]) => items.filter((item) => item.roles.includes(role));
 
   return (
     <aside className="glass-panel hidden lg:flex w-72 flex-col justify-between p-8">
       <div>
-        <div className="flex items-center gap-3">
+        <Link
+          to={homePath}
+          className="flex items-center gap-3 rounded-2xl p-2 transition hover:bg-white/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-500"
+        >
           <img src="/logo.svg" alt="MinifyAI" className="h-10 w-10" />
           <div>
             <p className="text-xs uppercase tracking-widest text-slate-500">MinifyAI</p>
             <h1 className="text-lg font-semibold text-slate-900 dark:text-white">Finance OS</h1>
           </div>
-        </div>
+        </Link>
         <div className="mt-10 space-y-6">
           <nav className="flex flex-col gap-2">
             <p className="px-4 text-xs uppercase tracking-widest text-slate-400">Рабочие области</p>
-            {filterByRole(workspaceNav).map(({ icon: Icon, label, to }) => (
-              <NavLink
-                key={to}
-                to={to}
-                className={({ isActive }) =>
-                  clsx(
+            {filterByRole(workspaceNav).map(({ icon: Icon, label, to }) => {
+              const active = isNavItemActive(to);
+              return (
+                <Link
+                  key={to}
+                  to={to}
+                  className={clsx(
                     'flex items-center gap-3 rounded-2xl px-4 py-3 text-left text-sm font-medium transition-all',
-                    isActive
+                    active
                       ? 'bg-brand-500/10 text-brand-700 dark:text-brand-200'
                       : 'text-slate-500 hover:bg-slate-100/60 dark:hover:bg-white/5'
-                  )
-                }
-              >
-                <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-500/10 text-brand-600">
-                  <Icon size={18} />
-                </span>
-                {label}
-              </NavLink>
-            ))}
+                  )}
+                >
+                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-500/10 text-brand-600">
+                    <Icon size={18} />
+                  </span>
+                  {label}
+                </Link>
+              );
+            })}
           </nav>
           <nav className="flex flex-col gap-2">
             <p className="px-4 text-xs uppercase tracking-widest text-slate-400">Продукт</p>
-            {filterByRole(productNav).map(({ icon: Icon, label, to }) => (
-              <NavLink
-                key={to}
-                to={to}
-                className={({ isActive }) =>
-                  clsx(
+            {filterByRole(productNav).map(({ icon: Icon, label, to }) => {
+              const active = isNavItemActive(to);
+              return (
+                <Link
+                  key={to}
+                  to={to}
+                  className={clsx(
                     'flex items-center gap-3 rounded-2xl px-4 py-3 text-left text-sm font-medium transition-all',
-                    isActive
+                    active
                       ? 'bg-brand-500/10 text-brand-700 dark:text-brand-200'
                       : 'text-slate-500 hover:bg-slate-100/60 dark:hover:bg-white/5'
-                  )
-                }
-              >
-                <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-500/10 text-brand-600">
-                  <Icon size={18} />
-                </span>
-                {label}
-              </NavLink>
-            ))}
+                  )}
+                >
+                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-500/10 text-brand-600">
+                    <Icon size={18} />
+                  </span>
+                  {label}
+                </Link>
+              );
+            })}
           </nav>
         </div>
       </div>

--- a/frontend/src/features/BudgetAssistant.tsx
+++ b/frontend/src/features/BudgetAssistant.tsx
@@ -1,5 +1,5 @@
-import { Sparkles, Upload } from 'lucide-react';
-import { FormEvent, useState } from 'react';
+import { Sparkles, Upload, X } from 'lucide-react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 import { useDashboardStore } from '@store/dashboardStore';
 import { formatDate } from '@utils/format';
 
@@ -9,60 +9,109 @@ export const BudgetAssistant = () => {
     sendChatPrompt: state.sendChatPrompt
   }));
   const [prompt, setPrompt] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+  }, [chatHistory, isOpen]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!prompt.trim()) return;
-    sendChatPrompt(prompt);
+    const trimmed = prompt.trim();
+    if (!trimmed) return;
+    sendChatPrompt(trimmed);
     setPrompt('');
   };
 
   return (
-    <section className="glass-panel flex h-full flex-col overflow-hidden p-6">
-      <header className="flex items-center gap-3">
-        <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-600">
-          <Sparkles size={20} />
-        </span>
-        <div>
-          <p className="text-xs uppercase tracking-widest text-slate-500">AI ассистент</p>
-          <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Чат по бюджету</h2>
-        </div>
-      </header>
-      <div className="mt-4 flex flex-1 flex-col gap-3 overflow-y-auto pr-2 text-sm scrollbar">
-        {chatHistory.map((message) => (
-          <article
-            key={message.id}
-            className={
-              message.role === 'assistant'
-                ? 'self-start rounded-3xl bg-brand-500/10 px-4 py-3 text-brand-700 dark:text-brand-200'
-                : 'self-end rounded-3xl bg-slate-900 px-4 py-3 text-white'
-            }
-          >
-            <p className="text-xs text-slate-400">
-              {message.role === 'assistant' ? 'MinifyAI' : 'Вы'} · {formatDate(message.createdAt)}
-            </p>
-            <p className="mt-1 whitespace-pre-line text-sm leading-relaxed">{message.content}</p>
-          </article>
-        ))}
-      </div>
-      <form onSubmit={handleSubmit} className="mt-4 flex items-center gap-3 rounded-3xl bg-white/80 px-4 py-3 shadow-inner dark:bg-white/5">
-        <input
-          value={prompt}
-          onChange={(event) => setPrompt(event.target.value)}
-          placeholder="Спроси у ИИ: куда можно сократить расходы?"
-          className="flex-1 border-none bg-transparent text-sm focus:outline-none"
-        />
-        <button type="button" className="rounded-full bg-white px-3 py-2 text-xs font-semibold text-slate-600 shadow">
-          <Upload size={14} /> История
-        </button>
-        <button
-          type="submit"
-          className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white shadow-lg disabled:opacity-40"
-          disabled={!prompt.trim()}
+    <div className="pointer-events-none fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
+      {isOpen && (
+        <div
+          id="ai-assistant-widget"
+          className="pointer-events-auto glass-panel flex h-[28rem] w-[min(420px,calc(100vw-3rem))] flex-col overflow-hidden shadow-2xl"
         >
-          Отправить
-        </button>
-      </form>
-    </section>
+          <header className="flex items-center justify-between border-b border-white/40 px-5 py-4">
+            <div className="flex items-center gap-3">
+              <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-600">
+                <Sparkles size={20} />
+              </span>
+              <div className="text-left">
+                <p className="text-xs uppercase tracking-widest text-slate-500">AI ассистент</p>
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Чат по бюджету</h2>
+              </div>
+            </div>
+            <button
+              type="button"
+              className="rounded-full p-2 text-slate-500 transition hover:bg-white/60 hover:text-slate-700"
+              onClick={() => setIsOpen(false)}
+              aria-label="Закрыть чат ассистента"
+            >
+              <X size={18} />
+            </button>
+          </header>
+          <div ref={scrollContainerRef} className="flex-1 space-y-3 overflow-y-auto px-5 py-4 text-sm scrollbar">
+            {chatHistory.length === 0 && (
+              <p className="rounded-2xl bg-white/60 px-4 py-3 text-sm text-slate-500">
+                Задайте вопрос, и ассистент поможет оптимизировать бюджет и подскажет, где можно сэкономить.
+              </p>
+            )}
+            {chatHistory.map((message) => (
+              <article
+                key={message.id}
+                className={
+                  message.role === 'assistant'
+                    ? 'self-start rounded-3xl bg-brand-500/10 px-4 py-3 text-brand-700 dark:text-brand-200'
+                    : 'self-end rounded-3xl bg-slate-900 px-4 py-3 text-white'
+                }
+              >
+                <p className="text-xs text-slate-400">
+                  {message.role === 'assistant' ? 'MinifyAI' : 'Вы'} · {formatDate(message.createdAt)}
+                </p>
+                <p className="mt-1 whitespace-pre-line text-sm leading-relaxed">{message.content}</p>
+              </article>
+            ))}
+          </div>
+          <form
+            onSubmit={handleSubmit}
+            className="border-t border-white/40 bg-white/70 px-5 py-4 dark:border-white/10 dark:bg-slate-900/60"
+          >
+            <div className="flex items-center gap-3 rounded-3xl bg-white/90 px-4 py-3 shadow-inner dark:bg-white/10">
+              <input
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                placeholder="Спроси у ИИ: куда можно сократить расходы?"
+                className="flex-1 border-none bg-transparent text-sm focus:outline-none"
+              />
+              <button
+                type="button"
+                className="hidden items-center gap-2 rounded-full bg-white px-3 py-2 text-xs font-semibold text-slate-600 shadow md:inline-flex"
+              >
+                <Upload size={14} /> История
+              </button>
+              <button
+                type="submit"
+                className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white shadow-lg transition enabled:hover:bg-brand-600 disabled:opacity-40"
+                disabled={!prompt.trim()}
+              >
+                Отправить
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-brand-500 px-5 py-3 text-sm font-semibold text-white shadow-xl transition hover:bg-brand-600"
+        aria-expanded={isOpen}
+        aria-controls="ai-assistant-widget"
+      >
+        <Sparkles size={18} /> AI ассистент
+      </button>
+    </div>
   );
 };

--- a/frontend/src/features/UserProfileSection.tsx
+++ b/frontend/src/features/UserProfileSection.tsx
@@ -1,0 +1,126 @@
+import dayjs from 'dayjs';
+import { useMemo } from 'react';
+import { useAuthStore } from '@store/authStore';
+import { useDashboardStore } from '@store/dashboardStore';
+import { formatDate } from '@utils/format';
+
+const roleLabels: Record<string, string> = {
+  admin: 'Администратор системы',
+  user: 'Пользователь'
+};
+
+const getInitials = (name?: string | null) => {
+  if (!name) return '??';
+  const parts = name.split(' ').filter(Boolean);
+  if (parts.length === 0) return '??';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+};
+
+export const UserProfileSection = () => {
+  const user = useAuthStore((state) => state.user);
+  const { selectedMonth, selectedCurrency, transactions, subscriptions, convertToSelectedCurrency } =
+    useDashboardStore((state) => ({
+      selectedMonth: state.selectedMonth,
+      selectedCurrency: state.selectedCurrency,
+      transactions: state.transactions,
+      subscriptions: state.subscriptions,
+      convertToSelectedCurrency: state.convertToSelectedCurrency
+    }));
+
+  const month = useMemo(() => dayjs(selectedMonth).format('MMMM YYYY'), [selectedMonth]);
+  const stats = useMemo(() => {
+    const monthDate = dayjs(selectedMonth);
+    const monthlyTransactions = transactions.filter((transaction) =>
+      dayjs(transaction.date).isSame(monthDate, 'month')
+    );
+
+    const totalIncome = monthlyTransactions
+      .filter((transaction) => transaction.type === 'income')
+      .reduce((sum, transaction) => sum + convertToSelectedCurrency(transaction.amount).amount, 0);
+    const totalExpenses = monthlyTransactions
+      .filter((transaction) => transaction.type === 'expense')
+      .reduce((sum, transaction) => sum + convertToSelectedCurrency(transaction.amount).amount, 0);
+
+    return {
+      income: totalIncome,
+      expenses: totalExpenses,
+      balance: totalIncome - totalExpenses
+    };
+  }, [convertToSelectedCurrency, selectedMonth, transactions]);
+
+  const activeSubscriptions = useMemo(
+    () => subscriptions.filter((subscription) => subscription.status === 'active'),
+    [subscriptions]
+  );
+
+  const nextPayment = useMemo(() => {
+    if (activeSubscriptions.length === 0) return null;
+    return activeSubscriptions
+      .slice()
+      .sort((a, b) => dayjs(a.nextPaymentDate).valueOf() - dayjs(b.nextPaymentDate).valueOf())[0];
+  }, [activeSubscriptions]);
+
+  const formatCurrency = (value: number) =>
+    value.toLocaleString('ru-RU', { style: 'currency', currency: selectedCurrency });
+
+  return (
+    <section
+      id="profile"
+      className="glass-panel grid gap-6 p-6 lg:grid-cols-[minmax(0,260px),1fr]"
+      aria-labelledby="user-profile-heading"
+    >
+      <div className="flex flex-col gap-4">
+        <span className="flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-brand-400 to-brand-600 text-lg font-semibold text-white">
+          {getInitials(user?.fullName)}
+        </span>
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Профиль</p>
+          <h2 id="user-profile-heading" className="text-2xl font-semibold text-slate-900 dark:text-white">
+            {user?.fullName ?? 'Неизвестный пользователь'}
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">{user?.email ?? '—'}</p>
+          <span className="inline-flex rounded-full bg-brand-500/10 px-3 py-1 text-xs font-medium text-brand-700 dark:text-brand-200">
+            {roleLabels[user?.role ?? 'user']}
+          </span>
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <article className="rounded-2xl border border-white/40 bg-white/70 p-4 shadow-sm dark:border-white/5 dark:bg-slate-900/60">
+          <p className="text-xs uppercase tracking-widest text-slate-400">Доходы за {month}</p>
+          <p className="mt-2 text-2xl font-semibold text-emerald-600 dark:text-emerald-400">{formatCurrency(stats.income)}</p>
+          <p className="mt-1 text-xs text-slate-500">Все поступления, зафиксированные в текущем месяце.</p>
+        </article>
+        <article className="rounded-2xl border border-white/40 bg-white/70 p-4 shadow-sm dark:border-white/5 dark:bg-slate-900/60">
+          <p className="text-xs uppercase tracking-widest text-slate-400">Расходы за {month}</p>
+          <p className="mt-2 text-2xl font-semibold text-rose-500">{formatCurrency(stats.expenses)}</p>
+          <p className="mt-1 text-xs text-slate-500">Сумма трат по всем категориям за выбранный месяц.</p>
+        </article>
+        <article className="rounded-2xl border border-dashed border-brand-400 bg-brand-500/10 p-4 shadow-sm dark:border-brand-300/40">
+          <p className="text-xs uppercase tracking-widest text-brand-600">Баланс месяца</p>
+          <p className="mt-2 text-2xl font-semibold text-brand-700 dark:text-brand-200">{formatCurrency(stats.balance)}</p>
+          <p className="mt-1 text-xs text-brand-700/70 dark:text-brand-200/80">
+            Разница между доходами и расходами за период.
+          </p>
+        </article>
+        <article className="rounded-2xl border border-white/40 bg-white/70 p-4 shadow-sm dark:border-white/5 dark:bg-slate-900/60">
+          <p className="text-xs uppercase tracking-widest text-slate-400">Активные подписки</p>
+          <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">{activeSubscriptions.length}</p>
+          <p className="mt-1 text-xs text-slate-500">Подписки со статусом «активна».</p>
+        </article>
+        <article className="rounded-2xl border border-white/40 bg-white/70 p-4 shadow-sm dark:border-white/5 dark:bg-slate-900/60">
+          <p className="text-xs uppercase tracking-widest text-slate-400">Ближайшее списание</p>
+          {nextPayment ? (
+            <div className="mt-2 space-y-1 text-sm text-slate-600 dark:text-slate-300">
+              <p className="font-semibold text-slate-900 dark:text-white">{nextPayment.name}</p>
+              <p>{formatDate(nextPayment.nextPaymentDate)}</p>
+              <p className="text-xs text-slate-400">{formatCurrency(convertToSelectedCurrency(nextPayment.amount).amount)}</p>
+            </div>
+          ) : (
+            <p className="mt-2 text-sm text-slate-500">Нет предстоящих платежей.</p>
+          )}
+        </article>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuthStore, selectIsAuthenticated } from '@store/authStore';
+
+export const NotFoundPage = () => {
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const role = useAuthStore((state) => state.user?.role ?? 'user');
+
+  const homePath = useMemo(() => {
+    if (!isAuthenticated) {
+      return '/login';
+    }
+    return role === 'admin' ? '/admin' : '/user';
+  }, [isAuthenticated, role]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-slate-50 px-6 py-16 text-center dark:bg-slate-900">
+      <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-500">404</p>
+      <h1 className="mt-4 text-4xl font-bold text-slate-900 dark:text-white sm:text-5xl">Страница не найдена</h1>
+      <p className="mt-3 max-w-xl text-base text-slate-500 dark:text-slate-400">
+        К сожалению, страница, которую вы ищете, была удалена, переименована или временно недоступна.
+      </p>
+      <Link
+        to={homePath}
+        className="mt-8 inline-flex items-center rounded-full bg-brand-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-brand-600"
+        replace
+      >
+        Вернуться на главную
+      </Link>
+    </div>
+  );
+};

--- a/frontend/src/pages/UserDashboardPage.tsx
+++ b/frontend/src/pages/UserDashboardPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { ActionBar } from '@components/layout/ActionBar';
-import { BudgetAssistant } from '@features/BudgetAssistant';
 import { CashflowChart } from '@features/CashflowChart';
 import { CategoryBreakdown } from '@features/CategoryBreakdown';
 import { DailyCalendar } from '@features/DailyCalendar';
@@ -10,6 +9,7 @@ import { SubscriptionsPanel } from '@features/SubscriptionsPanel';
 import { SubscriptionForecast } from '@features/SubscriptionForecast';
 import { TransactionsTable } from '@features/TransactionsTable';
 import { TransactionComposer } from '@features/TransactionComposer';
+import { UserProfileSection } from '@features/UserProfileSection';
 import { useDashboardStore } from '@store/dashboardStore';
 
 export const UserDashboardPage = () => {
@@ -23,6 +23,7 @@ export const UserDashboardPage = () => {
 
   return (
     <div className="space-y-6">
+      <UserProfileSection />
       <ActionBar />
       <OverviewCards />
       <TransactionComposer />
@@ -36,9 +37,8 @@ export const UserDashboardPage = () => {
         <SubscriptionForecast />
         <MultiCurrencyRates />
       </section>
-      <section id="transactions" className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+      <section id="transactions" className="grid gap-6">
         <TransactionsTable />
-        <BudgetAssistant />
       </section>
     </div>
   );

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -1,4 +1,9 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+const DEFAULT_API_BASE_URL =
+  typeof window !== 'undefined' && window.location.origin
+    ? window.location.origin
+    : 'http://localhost:3000';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? DEFAULT_API_BASE_URL;
 
 interface ApiClientOptions {
   authenticated?: boolean;


### PR DESCRIPTION
## Summary
- add a dedicated 404 page and route fallback
- convert the AI assistant into a floating widget and surface a profile overview card on the dashboard
- fix sidebar navigation highlighting, brand link behaviour, and improve the default API base URL detection

## Testing
- npm run lint *(fails: ESLint 9.34.0 requires an eslint.config.js migration)*

------
https://chatgpt.com/codex/tasks/task_e_68e57ae4045c8321abb95f7156fd05cc