### PR TITLE
Refine product navigation and AI assistant layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,10 @@ import { UserDashboardPage } from '@pages/UserDashboardPage';
 import { LoginPage } from '@pages/LoginPage';
 import { ProtectedRoute } from '@components/routing/ProtectedRoute';
 import { NotFoundPage } from '@pages/NotFoundPage';
+import { ProductOperationsPage } from '@pages/product/ProductOperationsPage';
+import { ProductSubscriptionsPage } from '@pages/product/ProductSubscriptionsPage';
+import { ProductAnalyticsPage } from '@pages/product/ProductAnalyticsPage';
+import { ProductSettingsPage } from '@pages/product/ProductSettingsPage';
 import { useAuthStore, selectIsAuthenticated } from '@store/authStore';
 
 const App = () => {
@@ -31,6 +35,17 @@ const App = () => {
         }
       >
         <Route path="/user" element={<UserDashboardPage />} />
+        <Route path="/product/operations" element={<ProductOperationsPage />} />
+        <Route path="/product/subscriptions" element={<ProductSubscriptionsPage />} />
+        <Route path="/product/analytics" element={<ProductAnalyticsPage />} />
+        <Route
+          path="/product/settings"
+          element={
+            <ProtectedRoute requiredRole="admin">
+              <ProductSettingsPage />
+            </ProtectedRoute>
+          }
+        />
         <Route
           path="/admin"
           element={

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Layers, PieChart, Settings, ShieldCheck, Wallet } from 'lucide-react';
+import { LayoutDashboard, Layers, PieChart, Settings, Wallet } from 'lucide-react';
 import clsx from 'classnames';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuthStore } from '@store/authStore';
@@ -11,16 +11,12 @@ interface NavItem {
   roles: UserRole[];
 }
 
-const workspaceNav: NavItem[] = [
-  { icon: LayoutDashboard, label: 'Личный кабинет', to: '/user', roles: ['user', 'admin'] },
-  { icon: ShieldCheck, label: 'Админ-панель', to: '/admin', roles: ['admin'] }
-];
-
 const productNav: NavItem[] = [
-  { icon: Wallet, label: 'Операции', to: '/user#transactions', roles: ['user', 'admin'] },
-  { icon: Layers, label: 'Подписки', to: '/user#subscriptions', roles: ['user', 'admin'] },
-  { icon: PieChart, label: 'Аналитика', to: '/user#analytics', roles: ['user', 'admin'] },
-  { icon: Settings, label: 'Настройки', to: '/admin#settings', roles: ['admin'] }
+  { icon: LayoutDashboard, label: 'Обзор', to: '/user', roles: ['user', 'admin'] },
+  { icon: Wallet, label: 'Операции', to: '/product/operations', roles: ['user', 'admin'] },
+  { icon: Layers, label: 'Подписки', to: '/product/subscriptions', roles: ['user', 'admin'] },
+  { icon: PieChart, label: 'Аналитика', to: '/product/analytics', roles: ['user', 'admin'] },
+  { icon: Settings, label: 'Настройки', to: '/product/settings', roles: ['admin'] }
 ];
 
 export const Sidebar = () => {
@@ -59,30 +55,7 @@ export const Sidebar = () => {
             <h1 className="text-lg font-semibold text-slate-900 dark:text-white">Finance OS</h1>
           </div>
         </Link>
-        <div className="mt-10 space-y-6">
-          <nav className="flex flex-col gap-2">
-            <p className="px-4 text-xs uppercase tracking-widest text-slate-400">Рабочие области</p>
-            {filterByRole(workspaceNav).map(({ icon: Icon, label, to }) => {
-              const active = isNavItemActive(to);
-              return (
-                <Link
-                  key={to}
-                  to={to}
-                  className={clsx(
-                    'flex items-center gap-3 rounded-2xl px-4 py-3 text-left text-sm font-medium transition-all',
-                    active
-                      ? 'bg-brand-500/10 text-brand-700 dark:text-brand-200'
-                      : 'text-slate-500 hover:bg-slate-100/60 dark:hover:bg-white/5'
-                  )}
-                >
-                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-500/10 text-brand-600">
-                    <Icon size={18} />
-                  </span>
-                  {label}
-                </Link>
-              );
-            })}
-          </nav>
+        <div className="mt-10">
           <nav className="flex flex-col gap-2">
             <p className="px-4 text-xs uppercase tracking-widest text-slate-400">Продукт</p>
             {filterByRole(productNav).map(({ icon: Icon, label, to }) => {

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -14,6 +14,22 @@ const routeMeta: Record<
     title: 'Личный кабинет',
     subtitle: 'Контролируйте личные финансы, подписки и аналитику.'
   },
+  '/product/operations': {
+    title: 'Операции',
+    subtitle: 'Управляйте платежами и контролируйте денежные потоки компании.'
+  },
+  '/product/subscriptions': {
+    title: 'Подписки',
+    subtitle: 'Отслеживайте SaaS-расходы и продления сервисов.'
+  },
+  '/product/analytics': {
+    title: 'Аналитика',
+    subtitle: 'Получайте визуальные отчёты и следите за ключевыми метриками.'
+  },
+  '/product/settings': {
+    title: 'Настройки',
+    subtitle: 'Управляйте безопасностью, ролями и интеграциями платформы.'
+  },
   '/admin': {
     title: 'Админ-панель',
     subtitle: 'Настраивайте команды, следите за метриками и безопасностью.'
@@ -119,7 +135,7 @@ export const TopBar = () => {
           {isMenuOpen && (
             <div
               role="menu"
-              className="absolute right-0 z-10 mt-2 w-56 rounded-2xl bg-white p-3 shadow-xl ring-1 ring-black/5"
+              className="absolute right-0 z-50 mt-2 w-56 rounded-2xl bg-white p-3 shadow-xl ring-1 ring-black/5"
             >
               <button
                 type="button"

--- a/frontend/src/features/BudgetAssistant.tsx
+++ b/frontend/src/features/BudgetAssistant.tsx
@@ -79,22 +79,22 @@ export const BudgetAssistant = () => {
             onSubmit={handleSubmit}
             className="border-t border-white/40 bg-white/70 px-5 py-4 dark:border-white/10 dark:bg-slate-900/60"
           >
-            <div className="flex items-center gap-3 rounded-3xl bg-white/90 px-4 py-3 shadow-inner dark:bg-white/10">
+            <div className="flex flex-wrap items-center gap-3 rounded-3xl bg-white/90 px-4 py-3 shadow-inner dark:bg-white/10 md:flex-nowrap">
               <input
                 value={prompt}
                 onChange={(event) => setPrompt(event.target.value)}
                 placeholder="Спроси у ИИ: куда можно сократить расходы?"
-                className="flex-1 border-none bg-transparent text-sm focus:outline-none"
+                className="min-w-0 basis-full flex-1 border-none bg-transparent text-sm focus:outline-none sm:basis-auto"
               />
               <button
                 type="button"
-                className="hidden items-center gap-2 rounded-full bg-white px-3 py-2 text-xs font-semibold text-slate-600 shadow md:inline-flex"
+                className="hidden h-10 items-center gap-2 rounded-full bg-white px-3 text-xs font-semibold text-slate-600 shadow md:inline-flex"
               >
                 <Upload size={14} /> История
               </button>
               <button
                 type="submit"
-                className="rounded-full bg-brand-500 px-4 py-2 text-sm font-semibold text-white shadow-lg transition enabled:hover:bg-brand-600 disabled:opacity-40"
+                className="inline-flex h-10 w-full items-center justify-center rounded-full bg-brand-500 px-5 text-sm font-semibold text-white shadow-lg transition enabled:hover:bg-brand-600 disabled:opacity-40 sm:w-auto"
                 disabled={!prompt.trim()}
               >
                 Отправить

--- a/frontend/src/pages/product/ProductAnalyticsPage.tsx
+++ b/frontend/src/pages/product/ProductAnalyticsPage.tsx
@@ -1,0 +1,47 @@
+import { BarChart3, Database, Gauge } from 'lucide-react';
+
+const insights = [
+  {
+    icon: BarChart3,
+    title: 'Интерактивные панели',
+    description:
+      'Стройте собственные дашборды с ключевыми показателями: выручка, burn-rate, удержание клиентов и эффективность маркетинга.'
+  },
+  {
+    icon: Database,
+    title: 'Единый источник данных',
+    description:
+      'Объединяйте банковские операции, CRM и данные бухгалтерии в одной витрине и анализируйте их без сложной настройки.'
+  },
+  {
+    icon: Gauge,
+    title: 'Мониторинг отклонений',
+    description:
+      'Настраивайте алерты по любым метрикам: система предупредит о превышении бюджетов или падении доходов.'
+  }
+];
+
+export const ProductAnalyticsPage = () => {
+  return (
+    <div className="space-y-6">
+      <section className="glass-panel space-y-4 p-6">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Аналитика и отчётность</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Получайте наглядную картину финансового состояния бизнеса — от ежедневных транзакций до долгосрочных трендов.
+          Используйте готовые шаблоны или создавайте свои панели аналитики.
+        </p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {insights.map(({ icon: Icon, title, description }) => (
+          <article key={title} className="glass-panel space-y-3 p-6">
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-600">
+              <Icon size={20} />
+            </span>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
+            <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">{description}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/pages/product/ProductOperationsPage.tsx
+++ b/frontend/src/pages/product/ProductOperationsPage.tsx
@@ -1,0 +1,47 @@
+import { CheckCircle, Clock, FileBarChart } from 'lucide-react';
+
+const highlights = [
+  {
+    icon: CheckCircle,
+    title: 'Автоматическая категоризация',
+    description:
+      'Загружайте выписки из любых банков и получайте мгновенную расшифровку операций с умной категоризацией и тегированием.'
+  },
+  {
+    icon: FileBarChart,
+    title: 'Глубокая аналитика расходов',
+    description:
+      'Отслеживайте траты по мерчантам, проектам и пользователям, строите отчёты за любые периоды и экспортируйте их для команды.'
+  },
+  {
+    icon: Clock,
+    title: 'Сценарии и напоминания',
+    description:
+      'Настраивайте автоматические сценарии, напоминания о платежах и контроль лимитов, чтобы ничего не упустить.'
+  }
+];
+
+export const ProductOperationsPage = () => {
+  return (
+    <div className="space-y-6">
+      <section className="glass-panel space-y-4 p-6">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Операции и контроль</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Управляйте денежными потоками компании в едином окне: собирайте операции из разных банков,
+          настраивайте автоматические правила и отслеживайте статусы платежей в режиме реального времени.
+        </p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {highlights.map(({ icon: Icon, title, description }) => (
+          <article key={title} className="glass-panel space-y-3 p-6">
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-600">
+              <Icon size={20} />
+            </span>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
+            <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">{description}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/pages/product/ProductSettingsPage.tsx
+++ b/frontend/src/pages/product/ProductSettingsPage.tsx
@@ -1,0 +1,47 @@
+import { KeyRound, Shield, Users } from 'lucide-react';
+
+const controls = [
+  {
+    icon: Users,
+    title: 'Роли и доступ',
+    description:
+      'Создавайте роли, управляйте командами и определяйте уровни доступа к финансовым данным и инструментам.'
+  },
+  {
+    icon: Shield,
+    title: 'Политики безопасности',
+    description:
+      'Включайте обязательную двухфакторную аутентификацию, настраивайте правила аудита и контроль рисковых операций.'
+  },
+  {
+    icon: KeyRound,
+    title: 'Интеграции и API',
+    description:
+      'Подключайте корпоративные системы, управляйте API-ключами и отслеживайте активность интеграций.'
+  }
+];
+
+export const ProductSettingsPage = () => {
+  return (
+    <div className="space-y-6">
+      <section className="glass-panel space-y-4 p-6">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Настройки и безопасность</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Централизованное управление политиками доступа, безопасностью и интеграциями. Настройте платформу под процессы вашей
+          компании и обеспечьте соблюдение требований комплаенса.
+        </p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {controls.map(({ icon: Icon, title, description }) => (
+          <article key={title} className="glass-panel space-y-3 p-6">
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-600">
+              <Icon size={20} />
+            </span>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
+            <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">{description}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/pages/product/ProductSubscriptionsPage.tsx
+++ b/frontend/src/pages/product/ProductSubscriptionsPage.tsx
@@ -1,0 +1,47 @@
+import { AlarmClock, CreditCard, ShieldCheck } from 'lucide-react';
+
+const benefits = [
+  {
+    icon: CreditCard,
+    title: 'Единый реестр подписок',
+    description:
+      'Все регулярные платежи компании собраны в одном календаре: отслеживайте статус оплаты, ответственных и бюджеты по командам.'
+  },
+  {
+    icon: AlarmClock,
+    title: 'Прогноз продлений',
+    description:
+      'Получайте прогнозы по предстоящим продлениям, чтобы заранее планировать бюджеты и избегать неожиданных расходов.'
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Контроль прав доступа',
+    description:
+      'Управляйте правами пользователей и интеграциями, фиксируйте владельцев подписок и следите за безопасностью доступа.'
+  }
+];
+
+export const ProductSubscriptionsPage = () => {
+  return (
+    <div className="space-y-6">
+      <section className="glass-panel space-y-4 p-6">
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">Подписки и сервисы</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Получайте прозрачность по всем SaaS-расходам: отслеживайте, кто пользуется сервисом, сколько он стоит и когда
+          потребуется продление.
+        </p>
+      </section>
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {benefits.map(({ icon: Icon, title, description }) => (
+          <article key={title} className="glass-panel space-y-3 p-6">
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-600">
+              <Icon size={20} />
+            </span>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
+            <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">{description}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- remove the "Рабочие области" section from the sidebar and point the product menu to dedicated routes
- add informational product pages and update routing metadata for the top bar
- ensure the profile dropdown appears above content and adjust the AI assistant form layout

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5828ae46883219da3992b1400a6f3